### PR TITLE
fix: import SelectChangeEvent from public @mui/material/Select entrypoint

### DIFF
--- a/lib/interface/analysis/filter/YearFilter.tsx
+++ b/lib/interface/analysis/filter/YearFilter.tsx
@@ -1,4 +1,4 @@
-import { SelectChangeEvent } from "@mui/material/Select/SelectInput";
+import { SelectChangeEvent } from "@mui/material/Select";
 import React, { Fragment, ReactElement, useEffect, useState } from "react";
 import TimeLog from "../../../domain/TimeLog";
 import _ from "lodash";

--- a/lib/interface/analysis/filter/YearSelect.tsx
+++ b/lib/interface/analysis/filter/YearSelect.tsx
@@ -1,4 +1,4 @@
-import { SelectChangeEvent } from "@mui/material/Select/SelectInput";
+import { SelectChangeEvent } from "@mui/material/Select";
 import React from "react";
 import { MenuItem, Select } from "@mui/material";
 


### PR DESCRIPTION
The internal `@mui/material/Select/SelectInput` subpath isn't exposed by MUI's package exports map under modern bundler module resolution, which both TypeScript 6 and recent Next.js versions push toward. This blocks several pending dependency bumps (#1216, #1198, #1195). Switches to the public `@mui/material/Select` export instead.

## Test plan
- [x] `npm run build` passes locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01DPSC8r6RRGNkYekWvtnPeG)_