### PR TITLE
feat: make time log week filter configurable via select box

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,16 @@ jobs:
       - name: Deploy to Vercel (preview)
         id: deploy
         run: |
-          url=$(npx vercel --token "$VERCEL_TOKEN" 2>&1 | tail -1)
+          set -eo pipefail
+          output=$(npx vercel --token "$VERCEL_TOKEN" 2>&1 | tee /dev/stderr)
+          url=$(echo "$output" | tail -1)
           echo "url=$url" >> "$GITHUB_OUTPUT"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Comment preview URL on PR
+        if: success()
         uses: actions/github-script@v7
         with:
           script: |
@@ -58,7 +61,9 @@ jobs:
       - name: Deploy to Vercel (production)
         id: deploy
         run: |
-          url=$(npx vercel --prod --token "$VERCEL_TOKEN" 2>&1 | tail -1)
+          set -eo pipefail
+          output=$(npx vercel --prod --token "$VERCEL_TOKEN" 2>&1 | tee /dev/stderr)
+          url=$(echo "$output" | tail -1)
           echo "url=$url" >> "$GITHUB_OUTPUT"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/lib/application/TimeLogApplicationService.ts
+++ b/lib/application/TimeLogApplicationService.ts
@@ -13,8 +13,8 @@ export default class TimeLogApplicationService {
     return await this.timeLogRepository.count();
   }
 
-  async getAllRecentTimeLogs() {
-    const recentLimitDate = startOfLastWeeks(WEEK_LIMIT);
+  async getAllRecentTimeLogs(weeks: number = WEEK_LIMIT) {
+    const recentLimitDate = startOfLastWeeks(weeks);
     return await this.timeLogRepository.allBefore(recentLimitDate);
   }
 

--- a/lib/domain/time-constants.ts
+++ b/lib/domain/time-constants.ts
@@ -4,6 +4,7 @@ export const SEC = 1000;
 export const MIN = 60 * SEC;
 export const HOUR = 60 * MIN;
 export const WEEK_LIMIT = 8;
+export const WEEK_LIMIT_OPTIONS = [4, 8, 12, 26, 52];
 export const MONDAY = 1;
 const TODAY = new Date();
 

--- a/lib/interface/TimerApp.tsx
+++ b/lib/interface/TimerApp.tsx
@@ -5,10 +5,12 @@ import TimerContainer from "./timer/TimerContainer";
 import { SnackbarProvider } from "notistack";
 import PersistenceWarning from "./PersistenceWarning";
 import { useTimeLogs } from "./hooks/useTimeLogs";
+import { useWeekLimit } from "./hooks/useWeekLimit";
 import Footer from "./footer/Footer";
 
 export default function TimerApp() {
-  const timeLogs = useTimeLogs();
+  const [weekLimit, setWeekLimit] = useWeekLimit();
+  const timeLogs = useTimeLogs(weekLimit);
 
   return (
     <>
@@ -16,7 +18,11 @@ export default function TimerApp() {
         <TimerContainer timeLogs={timeLogs} />
         <TimeLogSummary timeLogs={timeLogs} />
         <PersistenceWarning timeLogs={timeLogs} />
-        <TimeLogTable timeLogs={timeLogs} />
+        <TimeLogTable
+          timeLogs={timeLogs}
+          weekLimit={weekLimit}
+          onWeekLimitChange={setWeekLimit}
+        />
         <Footer />
       </SnackbarProvider>
     </>

--- a/lib/interface/hooks/useTimeLogs.tsx
+++ b/lib/interface/hooks/useTimeLogs.tsx
@@ -1,11 +1,12 @@
 import { useLiveQuery } from "dexie-react-hooks";
 import TimeLog from "../../domain/TimeLog";
 import { timeLogApplicationService } from "../../application/TimeLogApplicationService";
+import { WEEK_LIMIT } from "../../domain/time-constants";
 
-export function useTimeLogs() {
+export function useTimeLogs(weeks: number = WEEK_LIMIT) {
   return useLiveQuery(
-    () => timeLogApplicationService.getAllRecentTimeLogs(),
-    [],
+    () => timeLogApplicationService.getAllRecentTimeLogs(weeks),
+    [weeks],
     [] as TimeLog[]
   );
 }

--- a/lib/interface/hooks/useWeekLimit.tsx
+++ b/lib/interface/hooks/useWeekLimit.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import { WEEK_LIMIT } from "../../domain/time-constants";
+
+const STORAGE_KEY = "weekLimit";
+
+function readStoredWeekLimit(): number {
+  if (typeof window === "undefined") {
+    return WEEK_LIMIT;
+  }
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return stored ? Number(stored) : WEEK_LIMIT;
+}
+
+export function useWeekLimit() {
+  const [weekLimit, setWeekLimitState] = useState(readStoredWeekLimit);
+
+  function setWeekLimit(weeks: number) {
+    window.localStorage.setItem(STORAGE_KEY, String(weeks));
+    setWeekLimitState(weeks);
+  }
+
+  return [weekLimit, setWeekLimit] as const;
+}

--- a/lib/interface/table/MoreEntriesTableRow.tsx
+++ b/lib/interface/table/MoreEntriesTableRow.tsx
@@ -1,14 +1,39 @@
-import { WEEK_LIMIT } from "../../domain/time-constants";
+import { WEEK_LIMIT_OPTIONS } from "../../domain/time-constants";
 import SpannedTableRow from "./SpannedTableRow";
 
 interface Props {
   count: number;
+  weekLimit: number;
+  onWeekLimitChange: (weeks: number) => void;
 }
 
-export default function MoreEntriesTableRow({ count }: Props) {
+export default function MoreEntriesTableRow({
+  count,
+  weekLimit,
+  onWeekLimitChange,
+}: Props) {
   return (
     <SpannedTableRow>
-      {count} time logs are outdated after {WEEK_LIMIT} weeks.
+      {count > 0 && <>{count} time logs are outdated after </>}
+      {count <= 0 && <>Showing time logs of the last </>}
+      <select
+        value={weekLimit}
+        onChange={(event) => onWeekLimitChange(Number(event.target.value))}
+        style={{
+          border: "none",
+          background: "transparent",
+          color: "inherit",
+          font: "inherit",
+          cursor: "pointer",
+        }}
+      >
+        {WEEK_LIMIT_OPTIONS.map((weeks) => (
+          <option key={weeks} value={weeks}>
+            {weeks}
+          </option>
+        ))}
+      </select>{" "}
+      weeks.
     </SpannedTableRow>
   );
 }

--- a/lib/interface/table/TimeLogTable.tsx
+++ b/lib/interface/table/TimeLogTable.tsx
@@ -18,12 +18,17 @@ import MoreEntriesTableRow from "./MoreEntriesTableRow";
 
 interface Props {
   timeLogs: TimeLog[];
+  weekLimit: number;
+  onWeekLimitChange: (weeks: number) => void;
 }
 
-export default function TimerLogTable({ timeLogs }: Props) {
+export default function TimerLogTable({
+  timeLogs,
+  weekLimit,
+  onWeekLimitChange,
+}: Props) {
   const totalCount = useTimeLogCount();
   const hiddenTimeLogCount = totalCount - timeLogs.length;
-  const moreTimeLogs = hiddenTimeLogCount > 0;
 
   return (
     <TableContainer component={Paper}>
@@ -46,7 +51,11 @@ export default function TimerLogTable({ timeLogs }: Props) {
               timeLog={timeLog}
             />
           ))}
-          {moreTimeLogs && <MoreEntriesTableRow count={hiddenTimeLogCount} />}
+          <MoreEntriesTableRow
+            count={hiddenTimeLogCount}
+            weekLimit={weekLimit}
+            onWeekLimitChange={onWeekLimitChange}
+          />
         </TableBody>
       </Table>
     </TableContainer>


### PR DESCRIPTION
The recent time log filter was hardcoded to 8 weeks. Add an inline,
subtle select box next to the outdated-entries note at the bottom of
the table so users can pick their own lookback window, persisted in
localStorage.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DPSC8r6RRGNkYekWvtnPeG