### PR TITLE
fix(ci): use PAT for release-please so release events trigger deploy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Releases created with the default GITHUB_TOKEN don't trigger other
workflows (GitHub's anti-recursion protection), so deploy.yml's
release:published trigger never fired for any past release. Production
has been stuck on a stale build ever since. Switching to a PAT-backed
token lets the release event propagate normally.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SPs7WHfdE84nwQCWQTnafS