### PR TITLE
ci: auto-recover Dependabot PRs from out-of-sync lockfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
-      - run: npm ci
+      - name: Install dependencies
+        id: install
+        run: npm ci
+      - name: Recover from out-of-sync lockfile on Dependabot PRs
+        if: ${{ failure() && steps.install.outcome == 'failure' && github.actor == 'dependabot[bot]' }}
+        run: gh pr comment "$PR_URL" --body "@dependabot recreate"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Playwright browsers
         run: npx playwright install chromium
       - run: npm run build


### PR DESCRIPTION
Dependabot's lockfile-only updater occasionally drops transitive
dependency entries when bumping a single package, causing `npm ci`
to fail with EUSAGE on otherwise-unrelated PRs. Detect that failure
on Dependabot-authored runs and trigger `@dependabot recreate` to
force a clean lockfile regeneration instead of leaving the PR stuck.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AJKQ8LvuGhaQZRQTJog6dL