### PR TITLE
ci: pass --yes to vercel deploy to skip confirmation prompt

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         id: deploy
         run: |
           set -eo pipefail
-          output=$(npx vercel --token "$VERCEL_TOKEN" 2>&1 | tee /dev/stderr)
+          output=$(npx vercel --yes --token "$VERCEL_TOKEN" 2>&1 | tee /dev/stderr)
           url=$(echo "$output" | tail -1)
           echo "url=$url" >> "$GITHUB_OUTPUT"
         env:
@@ -62,7 +62,7 @@ jobs:
         id: deploy
         run: |
           set -eo pipefail
-          output=$(npx vercel --prod --token "$VERCEL_TOKEN" 2>&1 | tee /dev/stderr)
+          output=$(npx vercel --prod --yes --token "$VERCEL_TOKEN" 2>&1 | tee /dev/stderr)
           url=$(echo "$output" | tail -1)
           echo "url=$url" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
## Summary
- `vercel deploy` requires interactive confirmation by default, which made `deploy-preview` fail on every PR (e.g. `Error: Command 'vercel deploy' requires confirmation. Use option "--yes" to confirm.`)
- Adds `--yes` to both the preview and production `vercel` invocations in `deploy.yml` so they run non-interactively in GitHub Actions

Found while investigating why Dependabot PRs were stuck (separate `npm ci` lockfile issue already fixed/merged in #1255).

## Test plan
- [ ] Confirm `deploy-preview` check passes on this PR
- [ ] Confirm a future release still deploys to production successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJKQ8LvuGhaQZRQTJog6dL)_