### PR TITLE
fix(ci): grep deploy URL from vercel output instead of tail -1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -eo pipefail
           output=$(npx vercel --yes --token "$VERCEL_TOKEN" 2>&1 | tee /dev/stderr)
-          url=$(echo "$output" | tail -1)
+          url=$(echo "$output" | grep -Eo 'https://[a-zA-Z0-9.-]+\.vercel\.app' | tail -1)
           echo "url=$url" >> "$GITHUB_OUTPUT"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -37,13 +37,15 @@ jobs:
       - name: Comment preview URL on PR
         if: success()
         uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
         with:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🔍 Preview deployed to: ${{ steps.deploy.outputs.url }}`
+              body: `🔍 Preview deployed to: ${process.env.PREVIEW_URL}`
             })
 
   deploy-production:


### PR DESCRIPTION
Vercel CLI now prints a "To deploy to production" hint line after the
preview URL, so tail -1 captured that hint instead of the URL. The hint
text contains backticks, which broke the github-script template literal
when interpolated via ${{ }} (SyntaxError: Unexpected identifier 'vercel').
Extract the URL with a pattern match and pass it through env instead of
interpolating untrusted output directly into the JS source.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y9NkydypxopLZGvX4F2NmE