### PR TITLE
Make total overtime card visually clickable

### DIFF
--- a/lib/interface/stats/StatisticsCard.tsx
+++ b/lib/interface/stats/StatisticsCard.tsx
@@ -1,20 +1,28 @@
 import { Typography } from "@mui/material";
+import { ChevronRight } from "@mui/icons-material";
 import { ReactNode } from "react";
+import Link from "next/link";
 
 interface Props {
   title: ReactNode;
   children: ReactNode;
+  href?: string;
 }
 
-export default function StatisticsCard({ title, children }: Props) {
-  return (
+export default function StatisticsCard({ title, children, href }: Props) {
+  const content = (
     <div>
       <Typography
         color="textSecondary"
         gutterBottom
-        sx={{ textTransform: "uppercase" }}
+        sx={{
+          textTransform: "uppercase",
+          display: "flex",
+          alignItems: "center",
+        }}
       >
         {title}
+        {href && <ChevronRight fontSize="small" />}
       </Typography>
       <Typography
         variant="body2"
@@ -26,5 +34,22 @@ export default function StatisticsCard({ title, children }: Props) {
         {children}
       </Typography>
     </div>
+  );
+
+  if (!href) {
+    return content;
+  }
+
+  return (
+    <Link
+      href={href}
+      style={{
+        textDecoration: "none",
+        color: "inherit",
+        cursor: "pointer",
+      }}
+    >
+      {content}
+    </Link>
   );
 }

--- a/lib/interface/stats/TimeLogSummary.tsx
+++ b/lib/interface/stats/TimeLogSummary.tsx
@@ -4,7 +4,6 @@ import Duration from "../Duration";
 import TimeLogStatistics from "../../domain/TimeLogStatistics";
 import StatisticsCard from "./StatisticsCard";
 import StatisticsRow from "./StatisticsRow";
-import Link from "next/link";
 
 interface Props {
   timeLogs: TimeLog[];
@@ -24,7 +23,7 @@ export default function TimeLogSummary({ timeLogs }: Props) {
           <Duration milliseconds={weeklyOvertimeMs} />
         </StatisticsCard>
       )}
-      <StatisticsCard title={<Link href={"/analysis"}>total overtime</Link>}>
+      <StatisticsCard title="total overtime" href="/analysis">
         <Duration milliseconds={totalOvertimeMs} />
       </StatisticsCard>
     </StatisticsRow>


### PR DESCRIPTION
Wrap the whole "total overtime" card in the link instead of just the
label text, and add a chevron icon so it's clear the value leads to
the statistics screen.