### PR TITLE
fix: pin yaml devDependency to stop Dependabot lockfile-drift loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,17 @@ jobs:
         run: npm ci
       - name: Recover from out-of-sync lockfile on Dependabot PRs
         if: ${{ failure() && steps.install.outcome == 'failure' && github.actor == 'dependabot[bot]' }}
-        run: gh pr comment "$PR_URL" --body "@dependabot recreate"
+        run: |
+          set -euo pipefail
+          ALREADY_TRIED=$(gh pr view "$PR_URL" --json comments --jq \
+            '[.comments[].body | select(contains("auto-recreate requested"))] | length')
+          if [ "$ALREADY_TRIED" -gt 0 ]; then
+            gh pr comment "$PR_URL" --body "⚠️ \`npm ci\` failed again after a previous automatic \`@dependabot recreate\` attempt. Not retrying again to avoid an infinite loop — this needs human investigation."
+            gh pr edit "$PR_URL" --add-label "needs-triage" || true
+          else
+            gh pr comment "$PR_URL" --body "🔁 auto-recreate requested: \`npm ci\` failed with an out-of-sync lockfile. Asking Dependabot to recreate this PR (one automatic attempt; will not retry indefinitely if this recurs)."
+            gh pr comment "$PR_URL" --body "@dependabot recreate"
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,17 @@ jobs:
               repo: context.repo.repo,
               body: `🔍 Preview deployed to: ${process.env.PREVIEW_URL}`
             })
+      - name: Comment deploy failure on PR
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ Preview deploy failed. Check the workflow run for details.`
+            })
 
   deploy-production:
     if: github.event_name == 'release'

--- a/docs/adr/0001-pin-transitive-optional-peer-deps.md
+++ b/docs/adr/0001-pin-transitive-optional-peer-deps.md
@@ -1,0 +1,92 @@
+# 1. Pin auto-resolved optional peer dependencies directly, not via `overrides`
+
+Status: Accepted
+
+Note: this repo otherwise uses `docs/adr/` for domain/business decisions
+(see `docs/agents/domain.md`). This entry is a deliberate exception — the
+failure mode it documents is subtle enough, and recurred silently for long
+enough, that it's worth preserving the reasoning for future maintainers and
+agents even though it's infra rather than domain.
+
+## Context
+
+Every open Dependabot PR started failing `npm ci` in CI with:
+
+```
+npm error Missing: yaml@2.9.0 from lock file
+```
+
+regardless of which unrelated package the PR actually bumped (mui, next,
+prettier, recharts, typescript-eslint, sentry, eslint were all observed).
+`main` itself was not broken — `npm ci` passed cleanly against it.
+
+Root cause: `vitest` declares `yaml` as an *optional peerDependency*
+(`^2.4.2`). npm auto-satisfies this with a nested
+`node_modules/vitest/node_modules/yaml` entry, recorded in the lockfile as
+`optional: true, peer: true`. Separately, `cosmiconfig` (pulled in via
+`next-pwa` → `babel-loader` → `babel-plugin-macros`) requires
+`yaml@^1.10.0`, resolved as an ordinary top-level `node_modules/yaml`.
+
+Dependabot's own lockfile updater does not reliably preserve that
+auto-resolved, flagged-optional-peer entry when regenerating the lock for
+an unrelated bump — it silently drops it. `npm ci`'s strict tree-vs-lock
+consistency check then fails, because vitest's peer requirement is still
+declared but nothing in the lock satisfies it.
+
+CI already had a self-heal for out-of-sync Dependabot lockfiles: on
+install failure it commented `@dependabot recreate`. But since Dependabot
+regenerates the lock the same buggy way every time, this looped forever —
+every affected PR sat blocked indefinitely rather than being fixed by the
+retry.
+
+## Considered and rejected: `package.json` `overrides`
+
+The obvious-looking fix is to pin the nested resolution via `overrides`:
+
+```json
+"overrides": { "vitest": { "yaml": "2.9.0" } }
+```
+
+This was tested in an isolated copy of the repo by regenerating the lock
+from scratch with and without the override. The resulting
+`node_modules/vitest/node_modules/yaml` entry was **byte-for-byte
+identical** either way — same version, same `optional: true, peer: true`
+flags. `overrides` only constrains *which version* npm picks when there's
+a choice to make; it doesn't change *how* the dependency edge gets
+recorded. The fragile "auto-resolved optional peer" shape — the actual
+thing Dependabot's updater mishandles — is untouched. **`overrides` is a
+no-op for this class of bug. Do not use it here.**
+
+## Decision
+
+Pin `yaml` as an explicit, direct `devDependency`:
+
+```json
+"yaml": "2.9.0"
+```
+
+(matching this repo's `.npmrc` `save-exact=true` convention). This makes
+npm hoist a normal top-level `node_modules/yaml` entry with no
+`optional`/`peer` flags at all — eliminating the fragile auto-resolved
+node entirely. `cosmiconfig`'s separate `yaml@^1.10.0` need still gets its
+own ordinary nested copy; the two versions coexist without conflict.
+
+Verified: `npm ci`, `npx vitest run` (106 tests), `npx tsc --noEmit`,
+`npx eslint .`, and `npm run build` all pass. A simulated Dependabot-style
+bump (`npm install <pkg> --save-dev --save-exact --package-lock-only`,
+mirroring exactly what the blocked PRs do) leaves the yaml entries stable
+through a subsequent fresh `npm ci`.
+
+Also updated `.github/workflows/ci.yml`'s recovery step to stop looping
+forever: it now attempts `@dependabot recreate` once, and if `npm ci`
+fails again after that, labels the PR `needs-triage` and stops instead of
+retrying indefinitely.
+
+## General principle for future recurrences
+
+If Dependabot repeatedly fails to regenerate a lockfile for an otherwise
+unrelated bump, suspect an auto-resolved optional/peer transitive
+dependency getting dropped, not a real conflict with the bumped package.
+Pin the transitive dependency directly as a `dependency`/`devDependency`
+rather than reaching for `overrides` — `overrides` does not fix this
+class of bug.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,8 @@
         "npm-run-all": "4.1.5",
         "prettier": "3.8.4",
         "typescript": "6.0.3",
-        "vitest": "4.1.9"
+        "vitest": "4.1.9",
+        "yaml": "2.9.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6224,6 +6225,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "license": "MIT",
@@ -12381,24 +12391,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "dev": true,
@@ -13135,10 +13127,19 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "npm-run-all": "4.1.5",
     "prettier": "3.8.4",
     "typescript": "6.0.3",
-    "vitest": "4.1.9"
+    "vitest": "4.1.9",
+    "yaml": "2.9.0"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- All 7 currently-open Dependabot PRs (#1278, #1277, #1276, #1275, #1273, #1261, #1241) are blocked because `npm ci` fails in CI with `Missing: yaml@2.9.0 from lock file` — regardless of which unrelated package each PR bumps.
- Root cause: `vitest` declares `yaml` as an optional peerDependency, which npm auto-resolves into a nested lockfile entry flagged `optional: true, peer: true`. Dependabot's own lockfile updater doesn't reliably preserve that entry when regenerating the lock for an unrelated bump, so it silently drops it and `npm ci`'s consistency check fails.
- CI already had a self-heal (comment `·@·d·ependabot r·ecreate` on failure), but since Dependabot regenerates the lock the same buggy way every time, it looped forever instead of fixing anything — that's why these PRs have sat blocked for days/weeks.
- Tested and rejected `package.json` `overrides` as a fix: it produces a byte-identical lockfile entry either way, since `overrides` only constrains *which* version is picked, not *how* the dependency edge is recorded.
- Fix: pin `yaml` as an explicit, direct `devDependency` (`"yaml": "2.9.0"`, matching this repo's `.npmrc` `save-exact=true` convention). This hoists a normal top-level `node_modules/yaml` entry with no optional/peer flags, eliminating the fragile auto-resolved node entirely. `cosmiconfig`'s separate `yaml@^1.10.0` need still resolves independently with no conflict.
- Bounded the `ci.yml` recovery step so a recurrence surfaces via `needs-triage` after one retry instead of looping `·@·d·ependabot r·ecreate` forever, and added failure-visibility to the preview deploy job in `deploy.yml`.
- Added `docs/adr/0001-pin-transitive-optional-peer-deps.md` (first ADR in this repo) documenting the root cause, the rejected `overrides` approach, and the general principle for recognizing this failure class again in the future.

## Test plan

- [x] `npm ci` succeeds cleanly against the regenerated lockfile
- [x] `npx vitest run` — 106/106 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — 0 errors (2 pre-existing unrelated warnings)
- [x] `npm run build` — succeeds, including the `next-pwa`/`cosmiconfig` build path that depends on the *other* yaml version
- [x] Simulated a Dependabot-style bump (`npm install prettier@3.9.4 --save-dev --save-exact --package-lock-only`) and confirmed a fresh `npm ci` still succeeds afterward
- [ ] After merge: rebase the 7 blocked Dependabot PRs (`·@·d·ependabot r·ebase`) and confirm their CI turns green


---
_Generated by [Claude Code](https://claude.ai/code/session_01A5nUKw2KUVyvMmRBZzdD8M)_