### PR TITLE
fix: show negative overtime as a red negative number instead of 0

### DIFF
--- a/lib/domain/analysis/Duration.test.tsx
+++ b/lib/domain/analysis/Duration.test.tsx
@@ -40,6 +40,16 @@ describe("Duration", () => {
         "1 d 1 h 1 m"
       );
     });
+
+    it("renders negative minutes", () => {
+      expect(new Duration(-1 * MIN).getFormatted()).toEqual("-1 m");
+    });
+
+    it("renders negative hours and minutes", () => {
+      expect(new Duration(-1 * HOUR - 1 * MIN).getFormatted()).toEqual(
+        "-1 h 1 m"
+      );
+    });
   });
 
   describe("getFormattedHours()", () => {

--- a/lib/domain/analysis/Duration.ts
+++ b/lib/domain/analysis/Duration.ts
@@ -5,7 +5,10 @@ export default class Duration {
   constructor(private milliseconds: number) {}
 
   getFormatted(withSeconds = false): string {
-    const { days, hours, minutes, seconds } = parseMs(this.milliseconds);
+    const isNegative = this.milliseconds < 0;
+    const { days, hours, minutes, seconds } = parseMs(
+      Math.abs(this.milliseconds)
+    );
 
     const parts = [];
 
@@ -25,7 +28,9 @@ export default class Duration {
       parts.push(`${seconds} s`);
     }
 
-    return parts.join(" ") || "0 s";
+    const formatted = parts.join(" ") || "0 s";
+
+    return isNegative ? `-${formatted}` : formatted;
   }
 
   getFormattedHours(): string {

--- a/lib/interface/Duration.test.tsx
+++ b/lib/interface/Duration.test.tsx
@@ -26,4 +26,16 @@ describe("<Duration />", () => {
 
     expect(await screen.findByText("1 h 1 m")).toBeInTheDocument();
   });
+
+  it("renders negative durations as a negative number instead of zero", async () => {
+    render(<Duration milliseconds={-1 * HOUR} />);
+
+    expect(await screen.findByText("-1 h")).toBeInTheDocument();
+  });
+
+  it("renders small negative durations as zero", async () => {
+    render(<Duration milliseconds={-500} />);
+
+    expect(await screen.findByText("0 s")).toBeInTheDocument();
+  });
 });

--- a/lib/interface/Duration.tsx
+++ b/lib/interface/Duration.tsx
@@ -1,3 +1,4 @@
+import { Box } from "@mui/material";
 import DomainDuration from "../domain/analysis/Duration";
 
 interface Props {
@@ -6,11 +7,19 @@ interface Props {
 }
 
 export default function Duration({ milliseconds, zero = "0 s" }: Props) {
-  if (milliseconds < 1000) {
+  if (Math.abs(milliseconds) < 1000) {
     return <span>{zero}</span>;
   }
 
   const formatted = new DomainDuration(milliseconds).getFormatted();
+
+  if (milliseconds < 0) {
+    return (
+      <Box component="span" sx={{ color: "error.main" }}>
+        {formatted}
+      </Box>
+    );
+  }
 
   return <span>{formatted}</span>;
 }


### PR DESCRIPTION
Duration's near-zero check used `milliseconds < 1000`, which caught
every negative value (not just near-zero ones), collapsing negative
overtime down to "0 s". Missing time now formats as a proper negative
duration (e.g. "-1 h 30 m") and renders in red.

Today's still-in-progress time was already excluded from the overtime
total (only completed past days count), so no domain logic changed.